### PR TITLE
transaction in user service

### DIFF
--- a/src/main/java/com/example/dashboard/user/service/UserService.java
+++ b/src/main/java/com/example/dashboard/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.example.dashboard.user.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -16,11 +17,12 @@ public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
-    public User findUserByEmail(String email) {
+    private User findUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(
                 ()-> new CommonException(ExceptionEnum.NOT_FOUND));
     }
 
+    @Transactional
     public void saveUser(String email, String password){
         Optional<User> optionalUser = userRepository.findByEmail(email);
         if(optionalUser.isPresent()) {
@@ -33,6 +35,7 @@ public class UserService {
         userRepository.save(user);
     }
 
+    @Transactional(readOnly = true)
     public User signin(String email, String password) {
         User user = this.findUserByEmail(email);
         if(!passwordEncoder.matches(password, user.getPassword())){


### PR DESCRIPTION
user service단에 transaction 처리함.

signin시 @transactional(readOnly = true)를 걸어 명확하게 read를 사용하여 실제 메모리에 조회만 가능하게 올림으로써 이구간에서 db 삽입이나 수정이 이뤄지지 않는다고 보장하며, 속도의 향상도 얻을 수 있다.
save 시 @transactional을 걸어 save가 실패했을 시 기존 상태로 rollback이 가능하도록 구현함.
( 단순 save여서 @transactional이 필요 없지만, entity에서 다른 entity와 매핑되었을 때를 위해 걸어둠)