### PR TITLE
add not null in user entity

### DIFF
--- a/src/main/java/com/example/dashboard/user/entity/User.java
+++ b/src/main/java/com/example/dashboard/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.example.dashboard.user.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,9 @@ public class User {
     private Long id;
 
     @Column(unique = true)
+    @NotNull
     private String email;
+
+    @NotNull
     private String password;
 }


### PR DESCRIPTION
user entity의 email과 password 부분에 not null을 추가하여 db 상의 각 필드를 null 값 불가로 지정